### PR TITLE
Fast Forward merge workflow 추가

### DIFF
--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -1,11 +1,17 @@
+name: Fast Forward Merge
+
 on:
   issue_comment:
     types: [created]
 
 jobs:
-  fast-forward-job:
+  fast-forward-merge:
     name: Fast Forward
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/fast-forward')
+    if: |
+      github.event.issue.pull_request && 
+      contains(github.event.comment.body, '/fast-forward') && 
+      (github.head_ref == 'develop' && github.base_ref == 'main') &&
+      (github.triggering_actor == 'onee-only' || github.triggering_actor == 'byundojin')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   fast-forward-merge:
-    name: Fast Forward
     if: |
       github.event.issue.pull_request && 
       contains(github.event.comment.body, '/fast-forward') && 

--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -1,0 +1,20 @@
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  fast-forward-job:
+    name: Fast Forward
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/fast-forward')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Fast Forward PR
+        uses: endre-spotlab/fast-forward-js-action@2.1
+        with:
+          GITHUB_TOKEN: ${{ secrets.FAST_FORWARD_GITHUB_TOKEN }}
+          success_message: "Success! Fast forwarded target_base to source_head! git checkout target_base && git merge source_head --ff-only "
+          failure_message: "Failed! Cannot do fast forward!"
+          production_branch: "main"
+          staging_branch: "develop"


### PR DESCRIPTION
현재 develop -> main PR은 merge commit이 남을 필요가 없습니다. 
때문에 main 브랜치의 HEAD 레퍼런스만 옮겨주는 Fast Forward Merge를 사용하는 것이 바람직합니다. 
하지만 GitHub은 위 기능을 [지원하지 않습니다](https://stackoverflow.com/a/65314973).

이를 해결하기 위해 Fast Forward Merge를 위한 GitHub Actions 워크플로우를 추가하였습니다.
이후 develop -> main PR의 코멘트에 `/fast-forward`를 입력하여 사용하면 됩니다.