### PR TITLE
ParsablePayload 구현

### DIFF
--- a/message/payload/__init__.py
+++ b/message/payload/__init__.py
@@ -2,3 +2,4 @@ from .internal.tiles_payload import FetchTilesPayload, TilesPayload, TilesEvent
 from .internal.base_payload import Payload
 from .internal.exceptions import InvalidFieldException, MissingFieldException
 from .internal.new_conn_payload import NewConnPayload, NewConnEvent, NearbyCursorPayload, CursorPayload, CursorAppearedPayload, NewCursorPayload
+from .internal.parsable_payload import ParsablePayload

--- a/message/payload/internal/base_payload.py
+++ b/message/payload/internal/base_payload.py
@@ -1,9 +1,9 @@
 from .exceptions import InvalidFieldException, MissingFieldException
+from .parsable_payload import ParsablePayload
+from typing import Generic
 
 
 class Payload():
-    event: str
-
     @classmethod
     def _from_dict(cls, dict: dict):
         kwargs = {}
@@ -19,6 +19,15 @@ class Payload():
                 raise InvalidFieldException(key, dict[key])
 
             t = cls.__annotations__[key]
+            if hasattr(t, "__origin__") and t.__origin__ == ParsablePayload:
+                if len(t.__args__) != 1:
+                    raise
+                try:
+                    kwargs[key] = t.__args__[0](**dict[key])
+                except:
+                    raise
+                continue
+
             if issubclass(t, Payload):
                 try:
                     kwargs[key] = t._from_dict(dict[key])

--- a/message/payload/internal/base_payload.py
+++ b/message/payload/internal/base_payload.py
@@ -25,7 +25,7 @@ class Payload():
                 try:
                     kwargs[key] = t.__args__[0](**dict[key])
                 except:
-                    raise MissingFieldException(key, e)
+                    raise InvalidFieldException(key, e)
                 continue
 
             if issubclass(t, Payload):

--- a/message/payload/internal/base_payload.py
+++ b/message/payload/internal/base_payload.py
@@ -1,4 +1,4 @@
-from .exceptions import InvalidFieldException, MissingFieldException
+from .exceptions import InvalidFieldException, MissingFieldException, DumbHumanException
 from .parsable_payload import ParsablePayload
 from typing import Generic
 
@@ -21,11 +21,11 @@ class Payload():
             t = cls.__annotations__[key]
             if hasattr(t, "__origin__") and t.__origin__ == ParsablePayload:
                 if len(t.__args__) != 1:
-                    raise
+                    raise DumbHumanException()
                 try:
                     kwargs[key] = t.__args__[0](**dict[key])
                 except:
-                    raise
+                    raise MissingFieldException(key, e)
                 continue
 
             if issubclass(t, Payload):

--- a/message/payload/internal/exceptions.py
+++ b/message/payload/internal/exceptions.py
@@ -31,3 +31,8 @@ class MissingFieldException(BaseException):
         if type(self.value) == self.__class__:
             return map(lambda key: f"{self.key}.{key}", self.value.get_keys())
         return self.key
+
+
+class DumbHumanException(BaseException):
+    def __repr__(self):
+        return "worng use"

--- a/message/payload/internal/parsable_payload.py
+++ b/message/payload/internal/parsable_payload.py
@@ -1,0 +1,7 @@
+from typing import TypeVar, Generic
+
+DATA_TYPE = TypeVar("DATA_TYPE")
+
+
+class ParsablePayload(Generic[DATA_TYPE]):
+    pass

--- a/message/payload/test/parsable_payload_test.py
+++ b/message/payload/test/parsable_payload_test.py
@@ -1,0 +1,36 @@
+import unittest
+from message.payload import Payload, ParsablePayload
+from dataclasses import dataclass
+
+
+@dataclass
+class ExampleData:
+    exp_str: str
+    exp_int: int
+
+
+@dataclass
+class ExamplePayload(Payload):
+    example_data: ParsablePayload[ExampleData]
+
+
+EXAMPLE_JSON = {
+    "example_data": {
+        "exp_str": "example",
+        "exp_int": 5
+    }
+}
+
+
+class ParserblePayloadTestCase(unittest.TestCase):
+    def test_parsing(self):
+        payload = ExamplePayload._from_dict(EXAMPLE_JSON)
+
+        self.assertEqual(type(payload), ExamplePayload)
+        self.assertEqual(type(payload.example_data), ExampleData)
+        self.assertEqual(payload.example_data.exp_str, "example")
+        self.assertEqual(payload.example_data.exp_int, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
더 유연한 payload typing 가능
hint type이랑 data랑 구조 같아야함

ex)
b
```
  point_x : int
  point_y : int
```
a
```
point : ParsablePayload[Point]
```