### PR TITLE
ConnectionManager.add에 new-conn 발행 로직 추가

### DIFF
--- a/conn/manager/internal/connection_manager.py
+++ b/conn/manager/internal/connection_manager.py
@@ -1,7 +1,7 @@
 from fastapi.websockets import WebSocket
 from conn import Conn
 from message import Message
-from message.payload import TilesPayload
+from message.payload import TilesPayload, NewConnEvent, NewConnPayload
 from event import EventBroker
 from uuid import uuid4
 
@@ -16,12 +16,23 @@ class ConnectionManager:
         return None
 
     @staticmethod
-    async def add(conn: WebSocket) -> Conn:
+    async def add(conn: WebSocket, width: int, height: int) -> Conn:
         id = ConnectionManager.generate_conn_id()
 
         conn_obj = Conn(id=id, conn=conn)
         await conn_obj.accept()
         ConnectionManager.conns[id] = conn_obj
+
+        message = Message(
+            event=NewConnEvent.NEW_CONN,
+            payload=NewConnPayload(
+                conn_id=id,
+                height=height,
+                width=width
+            )
+        )
+
+        await EventBroker.publish(message)
 
         return conn_obj
 

--- a/server.py
+++ b/server.py
@@ -7,7 +7,17 @@ app = FastAPI()
 
 @app.websocket("/session")
 async def session(ws: WebSocket):
-    conn = await ConnectionManager.add(ws)
+    try:
+        view_width = int(ws.headers["X-View-Tiles-Width"])
+        view_height = int(ws.headers["X-View-Tiles-Height"])
+    except KeyError:
+        await ws.close(code=400, reason="Missing required headers")
+        return
+    except ValueError:
+        await ws.close(code=400, reason="Headers are not properly typed")
+        return
+
+    conn = await ConnectionManager.add(ws, width=view_width, height=view_height)
 
     while True:
         try:

--- a/server_test.py
+++ b/server_test.py
@@ -1,41 +1,84 @@
 from fastapi.testclient import TestClient
+from fastapi.websockets import WebSocketDisconnect
 from server import app
 from message import Message
-from message.payload import FetchTilesPayload, TilesPayload, TilesEvent
+from message.payload import FetchTilesPayload, TilesPayload, TilesEvent, NewConnEvent
 from board.test.fixtures import setup_board
+from event import EventBroker
 
-client = TestClient(app)
+import unittest
+from unittest.mock import AsyncMock
 
 
-def test_fetch_tiles():
-    setup_board()
+class ServerTestCase(unittest.TestCase):
+    def setUp(self):
+        setup_board()
+        self.client = TestClient(app)
 
-    with client.websocket_connect("/session") as websocket:
-        msg = Message(
-            event=TilesEvent.FETCH_TILES,
-            payload=FetchTilesPayload(
-                start_x=-2,
-                start_y=1,
-                end_x=1,
-                end_y=-2
+        self.client.headers["X-View-Tiles-Width"] = "1"
+        self.client.headers["X-View-Tiles-Height"] = "1"
+
+    def tearDown(self):
+        self.client.headers = {}
+        self.client.close()
+
+    def test_no_headers(self):
+        self.client.headers = {}
+
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with self.client.websocket_connect("/session") as websocket:
+                websocket.close()
+
+    def test_wrong_headers(self):
+        self.client.headers["X-View-Tiles-Width"] = "string"
+
+        with self.assertRaises(WebSocketDisconnect) as cm:
+            with self.client.websocket_connect("/session") as websocket:
+                websocket.close()
+
+    def test_fetch_tiles(self):
+        # 기존 new-conn 리시버 비우기 및 mock으로 대체
+        self.new_conn_receivers = []
+        if NewConnEvent.NEW_CONN in EventBroker.event_dict:
+            self.new_conn_receivers = EventBroker.event_dict[NewConnEvent.NEW_CONN].copy()
+
+        EventBroker.event_dict[NewConnEvent.NEW_CONN] = []
+
+        self.mock_new_conn_func = AsyncMock()
+        self.mock_new_conn_receiver = EventBroker.add_receiver(NewConnEvent.NEW_CONN)(func=self.mock_new_conn_func)
+
+        with self.client.websocket_connect("/session") as websocket:
+            msg = Message(
+                event=TilesEvent.FETCH_TILES,
+                payload=FetchTilesPayload(
+                    start_x=-2,
+                    start_y=1,
+                    end_x=1,
+                    end_y=-2
+                )
             )
-        )
-        expect = Message(
-            event=TilesEvent.TILES,
-            payload=TilesPayload(
-                start_x=-2,
-                start_y=1,
-                end_x=1,
-                end_y=-2,
-                tiles="df12df12er56er56"
+
+            expect = Message(
+                event=TilesEvent.TILES,
+                payload=TilesPayload(
+                    start_x=-2,
+                    start_y=1,
+                    end_x=1,
+                    end_y=-2,
+                    tiles="df12df12er56er56"
+                )
             )
-        )
 
-        websocket.send_text(msg.to_str())
+            websocket.send_text(msg.to_str())
 
-        response = websocket.receive_text()
+            response = websocket.receive_text()
 
-        assert response == expect.to_str()
+            assert response == expect.to_str()
+
+        # 리시버 정상화
+        EventBroker.remove_receiver(self.mock_new_conn_receiver)
+        EventBroker.event_dict[NewConnEvent.NEW_CONN] = self.new_conn_receivers
 
 
-test_fetch_tiles()
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
+ws 핸들러에서 헤더 필드를 가져오고, 가져오지 못하면 커넥션을 닫는 로직을 추가했습니다.