### PR TITLE
singleton mock 구현

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -25,5 +25,6 @@ jobs:
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Test
         run: |
+          python -m tests.utils_test
           python -m tests.__init__
           python -m server_test

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,23 +1,22 @@
-import unittest
-
-# message
-from message.test import *
-from message.payload.test import *
-
-# event
-from event.test import *
-
-# board
-from board.test import *
-from board.handler.test import *
-
-# conn
-from conn.test import *
-from conn.manager.test import *
-
-# cursor
-from cursor.test import *
-from cursor.manager.test import *
-
 if __name__ == "__main__":
+    import unittest
+    # message
+    from message.test import *
+    from message.payload.test import *
+
+    # event
+    from event.test import *
+
+    # board
+    from board.test import *
+    from board.handler.test import *
+
+    # conn
+    from conn.test import *
+    from conn.manager.test import *
+
+    # cursor
+    from cursor.test import *
+    from cursor.manager.test import *
+
     unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,6 @@ def cases(case_list):
 
 
 def singleton_mock_setup(singleton_obj, mock, globals):
-    from pprint import pprint
     origin_object = singleton_obj
     globals[singleton_obj.__name__] = mock
     return origin_object

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -6,3 +6,39 @@ def cases(case_list):
                 func(*arg, **kwargs)
         return func_wrapper
     return wrapper
+
+
+def singleton_mock_setup(singleton_obj, mock, globals):
+    from pprint import pprint
+    origin_object = singleton_obj
+    globals[singleton_obj.__name__] = mock
+    return origin_object
+
+
+def singleton_mock_teardown(origin_object, globals):
+    globals[origin_object.__name__] = origin_object
+
+
+if __name__ == "__main__":
+    import unittest
+    from unittest.mock import MagicMock
+
+    class F:
+        pass
+
+    class SingletonMockTestCase(unittest.TestCase):
+        def setUp(self):
+            self.mock = MagicMock()
+            self.func_mock = MagicMock()
+            self.mock.func = self.func_mock
+
+            self.origin = singleton_mock_setup(F, self.mock, globals())
+
+        def tearDown(self):
+            singleton_mock_teardown(self.origin, globals())
+
+        def test_case(self):
+            F.func()
+            self.assertEqual(len(self.func_mock.mock_calls), 1)
+
+    unittest.main()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,28 +16,3 @@ def singleton_mock_setup(singleton_obj, mock, globals):
 
 def singleton_mock_teardown(origin_object, globals):
     globals[origin_object.__name__] = origin_object
-
-
-if __name__ == "__main__":
-    import unittest
-    from unittest.mock import MagicMock
-
-    class F:
-        pass
-
-    class SingletonMockTestCase(unittest.TestCase):
-        def setUp(self):
-            self.mock = MagicMock()
-            self.func_mock = MagicMock()
-            self.mock.func = self.func_mock
-
-            self.origin = singleton_mock_setup(F, self.mock, globals())
-
-        def tearDown(self):
-            singleton_mock_teardown(self.origin, globals())
-
-        def test_case(self):
-            F.func()
-            self.assertEqual(len(self.func_mock.mock_calls), 1)
-
-    unittest.main()

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,0 +1,25 @@
+from tests.utils import singleton_mock_setup, singleton_mock_teardown
+
+if __name__ == "__main__":
+    import unittest
+    from unittest.mock import MagicMock
+
+    class F:
+        pass
+
+    class SingletonMockTestCase(unittest.TestCase):
+        def setUp(self):
+            self.mock = MagicMock()
+            self.func_mock = MagicMock()
+            self.mock.func = self.func_mock
+
+            self.origin = singleton_mock_setup(F, self.mock, globals())
+
+        def tearDown(self):
+            singleton_mock_teardown(self.origin, globals())
+
+        def test_case(self):
+            F.func()
+            self.assertEqual(len(self.func_mock.mock_calls), 1)
+
+    unittest.main()


### PR DESCRIPTION
singleton 객체의 namespace값을 바꾸어 mocking 합니다.
mocking할때 namespace와 singleton 객체 mock 객체를 넘겨주고
반드시 teardown에서 mocking을 해제해야 합니다.