### PR TITLE
CursorManager의 pointing 관련 이벤트 리시버 추가

### DIFF
--- a/cursor/internal/cursor.py
+++ b/cursor/internal/cursor.py
@@ -8,6 +8,7 @@ class Cursor:
     conn_id: str
     position: Point
     pointer: Point | None
+    new_pointer: Point | None  # 새로운 포인터 후보
     color: Color
     width: int
     height: int
@@ -18,6 +19,7 @@ class Cursor:
             conn_id=conn_id,
             position=Point(0, 0),
             pointer=None,
+            new_pointer=None,
             color=Color.get_random(),
             width=0,
             height=0

--- a/cursor/manager/test/__init__.py
+++ b/cursor/manager/test/__init__.py
@@ -1,1 +1,1 @@
-from .cursor_manager_test import CursorManagerTestCase, CursorManagerNewConnTestCase
+from .cursor_manager_test import CursorManagerTestCase, CursorManagerNewConnTestCase, CursorManagerPointingTestCase

--- a/cursor/manager/test/cursor_manager_test.py
+++ b/cursor/manager/test/cursor_manager_test.py
@@ -2,11 +2,10 @@ from cursor import Cursor, Color
 from cursor.manager import CursorManager
 from event import EventBroker
 from message import Message
-from message.payload import NewConnEvent, NewConnPayload, PointEvent, PointingPayload, TryPointingPayload, PointingResultPayload, PointerSetPayload
+from message.payload import NewConnEvent, NewConnPayload, PointEvent, PointingPayload, TryPointingPayload, PointingResultPayload, PointerSetPayload, ClickType
 import unittest
-from unittest.mock import Mock, AsyncMock
+from unittest.mock import AsyncMock
 from board import Point
-from warnings import warn
 
 
 def get_cur(conn_id):
@@ -14,6 +13,7 @@ def get_cur(conn_id):
         conn_id=conn_id,
         position=Point(0, 0),
         pointer=None,
+        new_pointer=None,
         height=10,
         width=10,
         color=Color.BLUE
@@ -197,7 +197,7 @@ class CursorManagerPointingTestCase(unittest.IsolatedAsyncioTestCase):
             expected_conn_id: cursor
         }
 
-        click_type = "GENERAL_CLICK"
+        click_type = ClickType.GENERAL_CLICK
 
         message = Message(
             event=PointEvent.POINTING,

--- a/cursor/manager/test/cursor_manager_test.py
+++ b/cursor/manager/test/cursor_manager_test.py
@@ -2,7 +2,7 @@ from cursor import Cursor, Color
 from cursor.manager import CursorManager
 from event import EventBroker
 from message import Message
-from message.payload import NewConnEvent, NewConnPayload, PointEvent, PointingPayload, TryPointingPayload
+from message.payload import NewConnEvent, NewConnPayload, PointEvent, PointingPayload, TryPointingPayload, PointingResultPayload, PointerSetPayload
 import unittest
 from unittest.mock import Mock, AsyncMock
 from board import Point
@@ -165,10 +165,23 @@ class CursorManagerPointingTestCase(unittest.IsolatedAsyncioTestCase):
         self.mock_try_pointing_func = AsyncMock()
         self.mock_try_pointing_receiver = EventBroker.add_receiver(event=PointEvent.TRY_POINTING)(func=self.mock_try_pointing_func)
 
+        # 기존 pointable-result 리시버 비우기 및 mock으로 대체
+        self.pointer_set_receivers = []
+        if PointEvent.POINTER_SET in EventBroker.event_dict:
+            self.pointer_set_receivers = EventBroker.event_dict[PointEvent.POINTER_SET].copy()
+
+        EventBroker.event_dict[PointEvent.POINTER_SET] = []
+
+        self.mock_pointer_set_func = AsyncMock()
+        self.mock_pointer_set_receiver = EventBroker.add_receiver(event=PointEvent.POINTER_SET)(func=self.mock_pointer_set_func)
+
     def tearDown(self):
         # 리시버 정상화
         EventBroker.remove_receiver(self.mock_try_pointing_receiver)
         EventBroker.event_dict[PointEvent.TRY_POINTING] = self.try_pointing_receivers
+
+        EventBroker.remove_receiver(self.mock_pointer_set_receiver)
+        EventBroker.event_dict[PointEvent.POINTER_SET] = self.pointer_set_receivers
 
         CursorManager.cursor_dict = {}
 
@@ -212,6 +225,117 @@ class CursorManagerPointingTestCase(unittest.IsolatedAsyncioTestCase):
         assert got.payload.cursor_position == cursor.position
         assert got.payload.color == cursor.color
         assert got.payload.new_pointer == Point(0, 0)
+
+        assert cursor.new_pointer == message.payload.position
+
+    async def test_receive_pointing_result_pointable(self):
+        expected_conn_id = "example"
+
+        cursor = Cursor.create(conn_id=expected_conn_id)
+        cursor.pointer = Point(0, 0)
+        cursor.new_pointer = Point(0, 0)
+
+        CursorManager.cursor_dict = {
+            expected_conn_id: cursor
+        }
+
+        message = Message(
+            event=PointEvent.POINTING_RESULT,
+            header={"receiver": expected_conn_id},
+            payload=PointingResultPayload(
+                pointable=True,
+            )
+        )
+
+        await CursorManager.receive_pointing_result(message)
+
+        self.mock_pointer_set_func.assert_called_once()
+        got = self.mock_pointer_set_func.mock_calls[0].args[0]
+
+        assert type(got) == Message
+        assert got.event == PointEvent.POINTER_SET
+
+        assert "target_conns" in got.header
+        assert len(got.header["target_conns"]) == 1
+        assert got.header["target_conns"][0] == expected_conn_id
+
+        assert type(got.payload) == PointerSetPayload
+        assert got.payload.origin_position == Point(0, 0)
+        assert got.payload.color == cursor.color
+        assert got.payload.new_position == Point(0, 0)
+
+        assert cursor.pointer == got.payload.new_position
+        assert cursor.new_pointer == None
+
+    async def test_receive_pointing_result_not_pointable(self):
+        expected_conn_id = "example"
+
+        cursor = Cursor.create(conn_id=expected_conn_id)
+        cursor.pointer = Point(0, 0)
+
+        CursorManager.cursor_dict = {
+            expected_conn_id: cursor
+        }
+
+        message = Message(
+            event=PointEvent.POINTING_RESULT,
+            header={"receiver": expected_conn_id},
+            payload=PointingResultPayload(
+                pointable=False,
+            )
+        )
+
+        await CursorManager.receive_pointing_result(message)
+
+        self.mock_pointer_set_func.assert_called_once()
+        got = self.mock_pointer_set_func.mock_calls[0].args[0]
+
+        assert type(got) == Message
+        assert got.event == PointEvent.POINTER_SET
+
+        assert "target_conns" in got.header
+        assert len(got.header["target_conns"]) == 1
+        assert got.header["target_conns"][0] == expected_conn_id
+
+        assert type(got.payload) == PointerSetPayload
+        assert got.payload.origin_position == Point(0, 0)
+        assert got.payload.color == cursor.color
+        assert got.payload.new_position == None
+
+    async def test_receive_pointing_result_pointable_no_original_pointer(self):
+        expected_conn_id = "example"
+
+        cursor = Cursor.create(conn_id=expected_conn_id)
+        cursor.new_pointer = Point(0, 0)
+
+        CursorManager.cursor_dict = {
+            expected_conn_id: cursor
+        }
+
+        message = Message(
+            event=PointEvent.POINTING_RESULT,
+            header={"receiver": expected_conn_id},
+            payload=PointingResultPayload(
+                pointable=True,
+            )
+        )
+
+        await CursorManager.receive_pointing_result(message)
+
+        self.mock_pointer_set_func.assert_called_once()
+        got = self.mock_pointer_set_func.mock_calls[0].args[0]
+
+        assert type(got) == Message
+        assert got.event == PointEvent.POINTER_SET
+
+        assert "target_conns" in got.header
+        assert len(got.header["target_conns"]) == 1
+        assert got.header["target_conns"][0] == expected_conn_id
+
+        assert type(got.payload) == PointerSetPayload
+        assert got.payload.origin_position == None
+        assert got.payload.color == cursor.color
+        assert got.payload.new_position == Point(0, 0)
 
 
 if __name__ == "__main__":

--- a/message/payload/__init__.py
+++ b/message/payload/__init__.py
@@ -3,4 +3,4 @@ from .internal.base_payload import Payload
 from .internal.exceptions import InvalidFieldException, MissingFieldException
 from .internal.new_conn_payload import NewConnPayload, NewConnEvent, NearbyCursorPayload, CursorPayload, CursorAppearedPayload, NewCursorPayload
 from .internal.parsable_payload import ParsablePayload
-from .internal.pointing_payload import PointerSet, PointingResultPayload, PointingPayload, TryPointingPayload, PointEvent, ClickType
+from .internal.pointing_payload import PointerSetPayload, PointingResultPayload, PointingPayload, TryPointingPayload, PointEvent, ClickType

--- a/message/payload/internal/pointing_payload.py
+++ b/message/payload/internal/pointing_payload.py
@@ -38,7 +38,7 @@ class PointingResultPayload(Payload):
 
 
 @dataclass
-class PointerSet(ParsablePayload):
+class PointerSetPayload(ParsablePayload):
     oringin_position: ParsablePayload[Point]
     new_position: ParsablePayload[Point]
     color: Color

--- a/message/payload/internal/pointing_payload.py
+++ b/message/payload/internal/pointing_payload.py
@@ -39,6 +39,6 @@ class PointingResultPayload(Payload):
 
 @dataclass
 class PointerSetPayload(ParsablePayload):
-    oringin_position: ParsablePayload[Point]
-    new_position: ParsablePayload[Point]
+    origin_position: ParsablePayload[Point] | None
+    new_position: ParsablePayload[Point] | None
     color: Color


### PR DESCRIPTION
1. PointerSet -> PointerSetPayload로 이름 변경
2. CursorManager의 pointing, pointing-result 리시버 구현
3. Cursor에 new_pointer 필드 추가

pointing 이벤트 리시버에서 cursor의 뷰 바운더리를 벗어나는지 체크를 추가했습니다.
하지만 바운더리를 벗어나면 어떤 일이 일어나야하는지 의논을 하지 않았던 것 같아 일단 비워놨습니다.

#16 과 충돌이 생기면 PR 병합 후 다시 force-push 하겠습니다.