### PR TITLE
try-pointing receiver에 타일 업데이트 로직 추가

### DIFF
--- a/board/event/handler/internal/board_handler.py
+++ b/board/event/handler/internal/board_handler.py
@@ -120,32 +120,38 @@ class BoardEventHandler():
         match (click_type):
             # 닫힌 타일 열기
             case ClickType.GENERAL_CLICK:
+                if tile.is_flag:
+                    return
+
                 tile.is_open = True
                 tile.data |= 0b10000000
 
-                tile.is_flag = False
-                tile.color = None
-                tile.data &= 0b11000111
-            # 깃발 꽂기
+                
+            # 깃발 꽂기/뽑기
             case ClickType.SPECIAL_CLICK:
-                color = message.payload.color
-                tile.is_flag = True
-                tile.color = color
+                if tile.is_flag:
+                    tile.is_flag = False
+                    tile.color = None
+                    tile.data &= 0b11000111
+                else:
+                    color = message.payload.color
+                    tile.is_flag = True
+                    tile.color = color
 
-                # uh-oh..
-                match color:
-                    case Color.RED:
-                        color_to_int = 0
-                    case Color.YELLOW:
-                        color_to_int = 1
-                    case Color.BLUE:
-                        color_to_int = 2
-                    case Color.PURPLE:
-                        color_to_int = 3
+                    # uh-oh..
+                    match color:
+                        case Color.RED:
+                            color_to_int = 0
+                        case Color.YELLOW:
+                            color_to_int = 1
+                        case Color.BLUE:
+                            color_to_int = 2
+                        case Color.PURPLE:
+                            color_to_int = 3
 
-                color_to_int <<= 3
+                    color_to_int <<= 3
 
-                tile.data |= 0b00100000 | color_to_int
+                    tile.data |= 0b00100000 | color_to_int
 
         BoardHandler.update_tile(pointer, tile)
 

--- a/board/event/handler/internal/board_handler.py
+++ b/board/event/handler/internal/board_handler.py
@@ -1,8 +1,24 @@
 from event import EventBroker
 from board.data import Point, Tile
 from board.data.handler import BoardHandler
+from cursor.data import Color
 from message import Message
-from message.payload import FetchTilesPayload, TilesPayload, TilesEvent, NewConnEvent, NewConnPayload, TryPointingPayload, PointingResultPayload, PointEvent, MoveEvent, CheckMovablePayload, MovableResultPayload
+from message.payload import (
+    FetchTilesPayload,
+    TilesPayload,
+    TilesEvent,
+    NewConnEvent,
+    NewConnPayload,
+    TryPointingPayload,
+    PointingResultPayload,
+    PointEvent,
+    MoveEvent,
+    CheckMovablePayload,
+    MovableResultPayload,
+    ClickType,
+    InteractionEvent,
+    TileStateChangedPayload
+)
 
 
 class BoardEventHandler():
@@ -78,7 +94,7 @@ class BoardEventHandler():
                 pointable = True
                 break
 
-        message = Message(
+        pub_message = Message(
             event=PointEvent.POINTING_RESULT,
             header={"receiver": sender},
             payload=PointingResultPayload(
@@ -87,7 +103,61 @@ class BoardEventHandler():
             )
         )
 
-        await EventBroker.publish(message)
+        await EventBroker.publish(pub_message)
+
+        if not pointable:
+            return
+
+        # 보드 상태 업데이트하기
+        tile = Tile.from_int(tiles.data[4])  # 3x3칸 중 가운데
+        click_type = message.payload.click_type
+
+        if tile.is_open:
+            return
+
+        # TODO: data와 다른 필드들을 내부적으로 동기화시키기
+        # data를 @property로 만드는 것도?
+        match (click_type):
+            # 닫힌 타일 열기
+            case ClickType.GENERAL_CLICK:
+                tile.is_open = True
+                tile.data |= 0b10000000
+
+                tile.is_flag = False
+                tile.color = None
+                tile.data &= 0b11000111
+            # 깃발 꽂기
+            case ClickType.SPECIAL_CLICK:
+                color = message.payload.color
+                tile.is_flag = True
+                tile.color = color
+
+                # uh-oh..
+                match color:
+                    case Color.RED:
+                        color_to_int = 0
+                    case Color.YELLOW:
+                        color_to_int = 1
+                    case Color.BLUE:
+                        color_to_int = 2
+                    case Color.PURPLE:
+                        color_to_int = 3
+
+                color_to_int <<= 3
+
+                tile.data |= 0b00100000 | color_to_int
+
+        BoardHandler.update_tile(pointer, tile)
+
+        pub_message = Message(
+            event=InteractionEvent.TILE_STATE_CHANGED,
+            payload=TileStateChangedPayload(
+                position=pointer,
+                tile=tile
+            )
+        )
+
+        await EventBroker.publish(pub_message)
 
     @EventBroker.add_receiver(MoveEvent.CHECK_MOVABLE)
     @staticmethod

--- a/board/event/handler/test/board_handler_test.py
+++ b/board/event/handler/test/board_handler_test.py
@@ -138,7 +138,6 @@ class BoardEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestCa
             header={"sender": self.sender_id},
             payload=TryPointingPayload(
                 new_pointer=pointer,
-                cursor_position=Point(0, 0),
                 click_type=ClickType.GENERAL_CLICK,
                 color=Color.BLUE
             )
@@ -171,7 +170,6 @@ class BoardEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestCa
             header={"sender": self.sender_id},
             payload=TryPointingPayload(
                 new_pointer=pointer,
-                cursor_position=Point(0, 0),
                 click_type=ClickType.GENERAL_CLICK,
                 color=Color.BLUE
             )
@@ -204,7 +202,6 @@ class BoardEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestCa
             header={"sender": self.sender_id},
             payload=TryPointingPayload(
                 new_pointer=pointer,
-                cursor_position=Point(0, 0),
                 click_type=ClickType.GENERAL_CLICK,
                 color=Color.BLUE
             )

--- a/board/event/handler/test/board_handler_test.py
+++ b/board/event/handler/test/board_handler_test.py
@@ -1,10 +1,25 @@
 from cursor.data import Color
-from board.data import Point
+from board.data import Point, Tile
 from board.event.handler import BoardEventHandler
+from board.data.handler import BoardHandler
 from board.data.handler.test.fixtures import setup_board_fake, setup_board
 from message import Message
-from message.payload import \
-    FetchTilesPayload, TilesEvent, TilesPayload, NewConnEvent, NewConnPayload, TryPointingPayload, PointingResultPayload, PointEvent, ClickType, MoveEvent, CheckMovablePayload, MovableResultPayload
+from message.payload import (
+    FetchTilesPayload,
+    TilesEvent,
+    TilesPayload,
+    NewConnEvent,
+    NewConnPayload,
+    TryPointingPayload,
+    PointingResultPayload,
+    PointEvent,
+    ClickType,
+    MoveEvent,
+    CheckMovablePayload,
+    MovableResultPayload,
+    InteractionEvent,
+    TileStateChangedPayload
+)
 
 import unittest
 from unittest.mock import AsyncMock, patch
@@ -162,7 +177,7 @@ class BoardEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestCa
         self.assertEqual(got.payload.pointer, pointer)
 
     @patch("event.EventBroker.publish")
-    async def test_try_pointing_pointable_closed(self, mock: AsyncMock):
+    async def test_try_pointing_pointable_closed_general_click(self, mock: AsyncMock):
         pointer = Point(1, 0)
 
         message = Message(
@@ -177,21 +192,95 @@ class BoardEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestCa
 
         await BoardEventHandler.receive_try_pointing(message)
 
-        # pointing-result 발행하는지 확인
-        mock.assert_called_once()
+        # pointing-result, tile-state-changed 발행하는지 확인
+        self.assertEqual(len(mock.mock_calls), 2)
+
+        # pointing-result
         got: Message[PointingResultPayload] = mock.mock_calls[0].args[0]
         self.assertEqual(type(got), Message)
         self.assertEqual(got.event, PointEvent.POINTING_RESULT)
-
         # receiver 값 확인
         self.assertEqual(len(got.header), 1)
         self.assertIn("receiver", got.header)
         self.assertEqual(got.header["receiver"], self.sender_id)
-
         # payload 확인
         self.assertEqual(type(got.payload), PointingResultPayload)
         self.assertTrue(got.payload.pointable)
         self.assertEqual(got.payload.pointer, pointer)
+
+        # tile-state-changed
+        got: Message[PointingResultPayload] = mock.mock_calls[1].args[0]
+        self.assertEqual(type(got), Message)
+        self.assertEqual(got.event, InteractionEvent.TILE_STATE_CHANGED)
+        # payload 확인
+        self.assertEqual(type(got.payload), TileStateChangedPayload)
+        self.assertEqual(got.payload.position, pointer)
+
+        expected_tile = Tile.create(
+            is_open=True,
+            is_mine=False,
+            is_flag=False,
+            color=None,
+            number=1
+        )
+        fetched_tile = Tile.from_int(BoardHandler.fetch(start=pointer, end=pointer).data[0])
+
+        self.assertEqual(fetched_tile, expected_tile)
+        self.assertEqual(got.payload.tile, expected_tile)
+
+    @patch("event.EventBroker.publish")
+    async def test_try_pointing_pointable_closed_special_click(self, mock: AsyncMock):
+        pointer = Point(1, 0)
+        color = Color.BLUE
+
+        message = Message(
+            event=PointEvent.TRY_POINTING,
+            header={"sender": self.sender_id},
+            payload=TryPointingPayload(
+                new_pointer=pointer,
+                click_type=ClickType.SPECIAL_CLICK,
+                color=color
+            )
+        )
+
+        await BoardEventHandler.receive_try_pointing(message)
+
+        # pointing-result, tile-state-changed 발행하는지 확인
+        self.assertEqual(len(mock.mock_calls), 2)
+
+        # pointing-result
+        got: Message[PointingResultPayload] = mock.mock_calls[0].args[0]
+        self.assertEqual(type(got), Message)
+        self.assertEqual(got.event, PointEvent.POINTING_RESULT)
+        # receiver 값 확인
+        self.assertEqual(len(got.header), 1)
+        self.assertIn("receiver", got.header)
+        self.assertEqual(got.header["receiver"], self.sender_id)
+        # payload 확인
+        self.assertEqual(type(got.payload), PointingResultPayload)
+        self.assertTrue(got.payload.pointable)
+        self.assertEqual(got.payload.pointer, pointer)
+
+        # tile-state-changed
+        got: Message[PointingResultPayload] = mock.mock_calls[1].args[0]
+        self.assertEqual(type(got), Message)
+        self.assertEqual(got.event, InteractionEvent.TILE_STATE_CHANGED)
+        # payload 확인
+        self.assertEqual(type(got.payload), TileStateChangedPayload)
+        self.assertEqual(got.payload.position, pointer)
+
+        expected_tile = Tile.create(
+            is_open=False,
+            is_mine=False,
+            is_flag=True,
+            color=color,
+            number=1
+        )
+
+        fetched_tile = Tile.from_int(BoardHandler.fetch(start=pointer, end=pointer).data[0])
+
+        self.assertEqual(fetched_tile, expected_tile)
+        self.assertEqual(got.payload.tile, expected_tile)
 
     @patch("event.EventBroker.publish")
     async def test_try_pointing_not_pointable(self, mock: AsyncMock):

--- a/cursor/event/handler/internal/cursor_event_handler.py
+++ b/cursor/event/handler/internal/cursor_event_handler.py
@@ -90,7 +90,6 @@ class CursorEventHandler:
             event=PointEvent.TRY_POINTING,
             header={"sender": sender},
             payload=TryPointingPayload(
-                cursor_position=cursor.position,
                 new_pointer=new_pointer,
                 color=cursor.color,
                 click_type=message.payload.click_type

--- a/cursor/event/handler/test/cursor_event_handler_test.py
+++ b/cursor/event/handler/test/cursor_event_handler_test.py
@@ -283,7 +283,6 @@ class CursorEventHandler_PointingReceiver_TestCase(unittest.IsolatedAsyncioTestC
         # payload 확인
         self.assertEqual(type(got.payload), TryPointingPayload)
         self.assertEqual(got.payload.click_type, click_type)
-        self.assertEqual(got.payload.cursor_position, cursor.position)
         self.assertEqual(got.payload.color, cursor.color)
         self.assertEqual(got.payload.new_pointer, Point(0, 0))
 

--- a/message/payload/internal/pointing_payload.py
+++ b/message/payload/internal/pointing_payload.py
@@ -26,7 +26,6 @@ class PointingPayload(Payload):
 
 @dataclass
 class TryPointingPayload(Payload):
-    cursor_position: ParsablePayload[Point]
     new_pointer: ParsablePayload[Point]
     color: Color
     click_type: ClickType


### PR DESCRIPTION
+try-pointing payload에 cursor_position 필드가 사용처가 없어서 삭제했습니다. 

Tile의 data와 다른 필드들을 업데이트 시 동기화시키는 동작이 내부적으로 존재해야 할 것 같습니다.
일단 제가 생각하는 방법은 data를 `@property`로 만드는 방법인데, 다른 의견 있으면 자유롭게 제시해주세요.