### PR TITLE
conn close 관련 로직

### DIFF
--- a/conn/manager/internal/connection_manager.py
+++ b/conn/manager/internal/connection_manager.py
@@ -1,7 +1,7 @@
 from fastapi.websockets import WebSocket
 from conn import Conn
 from message import Message
-from message.payload import TilesPayload, NewConnEvent, NewConnPayload
+from message.payload import NewConnEvent, NewConnPayload, ConnClosedPayload
 from event import EventBroker
 from uuid import uuid4
 
@@ -46,6 +46,13 @@ class ConnectionManager:
 
     @staticmethod
     async def close(conn: Conn) -> Conn:
+        message = Message(
+            event=NewConnEvent.CONN_CLOSED,
+            header={"sender": conn.id},
+            payload=ConnClosedPayload()
+        )
+        await EventBroker.publish(message)
+
         ConnectionManager.conns.pop(conn.id)
 
     @staticmethod

--- a/conn/manager/internal/connection_manager.py
+++ b/conn/manager/internal/connection_manager.py
@@ -46,14 +46,14 @@ class ConnectionManager:
 
     @staticmethod
     async def close(conn: Conn) -> Conn:
+        ConnectionManager.conns.pop(conn.id)
+
         message = Message(
             event=NewConnEvent.CONN_CLOSED,
             header={"sender": conn.id},
             payload=ConnClosedPayload()
         )
         await EventBroker.publish(message)
-
-        ConnectionManager.conns.pop(conn.id)
 
     @staticmethod
     def generate_conn_id():

--- a/cursor/event/handler/internal/cursor_event_handler.py
+++ b/cursor/event/handler/internal/cursor_event_handler.py
@@ -315,6 +315,8 @@ class CursorEventHandler:
             other_cursor = CursorHandler.get_cursor(id)
             CursorHandler.remove_watcher(watcher=other_cursor, watching=cursor)
 
+        CursorHandler.remove_cursor(cursor.conn_id)
+
         message = Message(
             event="multicast",
             header={"target_conns": watchers,

--- a/cursor/event/handler/internal/cursor_event_handler.py
+++ b/cursor/event/handler/internal/cursor_event_handler.py
@@ -23,7 +23,9 @@ from message.payload import (
     InteractionEvent,
     TileStateChangedPayload,
     TileUpdatedPayload,
-    YouDiedPayload
+    YouDiedPayload,
+    ConnClosedPayload,
+    CursorQuitPayload
 )
 
 
@@ -294,6 +296,36 @@ class CursorEventHandler:
                 )
             )
             await EventBroker.publish(pub_message)
+
+    @EventBroker.add_receiver(NewConnEvent.CONN_CLOSED)
+    @staticmethod
+    async def receive_conn_closed(message: Message[ConnClosedPayload]):
+        sender = message.header["sender"]
+
+        cursor = CursorHandler.get_cursor(sender)
+
+        watching = CursorHandler.get_watching(cursor_id=cursor.conn_id)
+        watchers = CursorHandler.get_watchers(cursor_id=cursor.conn_id)
+
+        for id in watching:
+            other_cursor = CursorHandler.get_cursor(id)
+            CursorHandler.remove_watcher(watcher=cursor, watching=other_cursor)
+
+        for id in watchers:
+            other_cursor = CursorHandler.get_cursor(id)
+            CursorHandler.remove_watcher(watcher=other_cursor, watching=cursor)
+
+        message = Message(
+            event="multicast",
+            header={"target_conns": watchers,
+                    "origin_event": NewConnEvent.CURSOR_QUIT},
+            payload=CursorQuitPayload(
+                position=cursor.position,
+                pointer=cursor.pointer,
+                color=cursor.color
+            )
+        )
+        await EventBroker.publish(message)
 
 
 async def publish_new_cursors_event(target_cursors: list[Cursor], cursors: list[Cursor]):

--- a/cursor/event/handler/test/__init__.py
+++ b/cursor/event/handler/test/__init__.py
@@ -2,5 +2,6 @@ from .cursor_event_handler_test import (
     CursorEventHandler_NewConnReceiver_TestCase,
     CursorEventHandler_PointingReceiver_TestCase,
     CursorEventHandler_MovingReceiver_TestCase,
-    CursorEventHandler_TileStateChanged_TestCase
+    CursorEventHandler_TileStateChanged_TestCase,
+    CursorEventHandler_ConnClosed_TestCase
 )

--- a/cursor/event/handler/test/cursor_event_handler_test.py
+++ b/cursor/event/handler/test/cursor_event_handler_test.py
@@ -847,6 +847,9 @@ class CursorEventHandler_ConnClosed_TestCase(unittest.IsolatedAsyncioTestCase):
         self.assertEqual(len(c_watchers), 1)
         self.assertIn("B", c_watchers)
 
+        # 커서 지워졌나 확인
+        self.assertIsNone(CursorHandler.get_cursor(self.cur_a.conn_id))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/cursor/event/handler/test/fixtures.py
+++ b/cursor/event/handler/test/fixtures.py
@@ -1,0 +1,53 @@
+from board.data import Point
+from cursor.data import Cursor, Color
+from cursor.data.handler import CursorHandler
+
+
+def setup_cursor_locations() -> tuple[Cursor]:
+    """
+    /docs/example/cursor-location.png
+
+    A, B, C 차례로 반환
+    """
+    CursorHandler.cursor_dict = {
+        "A": Cursor(
+            conn_id="A",
+            position=Point(-3, 3),
+            pointer=None,
+            height=6,
+            width=6,
+            color=Color.YELLOW,
+            revive_at=None
+        ),
+        "B": Cursor(
+            conn_id="B",
+            position=Point(-3, -4),
+            pointer=None,
+            height=7,
+            width=7,
+            color=Color.BLUE,
+            revive_at=None
+        ),
+        "C": Cursor(
+            conn_id="C",
+            position=Point(2, -1),
+            pointer=None,
+            height=4,
+            width=4,
+            color=Color.PURPLE,
+            revive_at=None
+        )
+    }
+
+    cur_a = CursorHandler.cursor_dict["A"]
+    cur_b = CursorHandler.cursor_dict["B"]
+    cur_c = CursorHandler.cursor_dict["C"]
+
+    CursorHandler.watchers = {}
+    CursorHandler.watching = {}
+
+    CursorHandler.add_watcher(watcher=cur_b, watching=cur_a)
+    CursorHandler.add_watcher(watcher=cur_b, watching=cur_c)
+    CursorHandler.add_watcher(watcher=cur_a, watching=cur_c)
+
+    return (cur_a, cur_b, cur_c)


### PR DESCRIPTION
#40 에 종속적인 PR입니다.

conn-closed 발행과 처리 로직을 작성했습니다.

추가로 cursor locations에 대한 데이터를 fixture로 만들어 `setup_cursor_locations` 함수로 뺐습니다.