### PR TITLE
Section.create 로직에 number 부분 추가

### DIFF
--- a/board/data/internal/section.py
+++ b/board/data/internal/section.py
@@ -72,13 +72,47 @@ class Section:
             else:
                 mine -= 1
             return q
-        # TODO: number도 저장하기
+
+        mine_tile = 0b01000000
+        closed_tile = 0b00000000
+
         data = bytearray(
-            0b00000000
-            if rand_choice()
-            else 0b01000000
+            closed_tile if rand_choice() else mine_tile
             for _ in range(total)
         )
+
+        # (x, y)
+        delta = [
+            (0, 1), (0, -1), (-1, 0), (1, 0),  # 상하좌우
+            (-1, 1), (1, 1), (-1, -1), (1, -1),  # 좌상 우상 좌하 우하
+        ]
+
+        # 지뢰 주변에 숫자 1씩 증가시키기
+        for y in range(Section.LENGTH):
+            for x in range(Section.LENGTH):
+                idx = (y * Section.LENGTH) + x
+                tile = data[idx]
+
+                if tile != mine_tile:
+                    continue
+
+                # 주변 탐색
+                for dx, dy in delta:
+                    nx, ny = x+dx, y+dy
+                    if \
+                            nx < 0 or nx >= Section.LENGTH or \
+                            ny < 0 or ny >= Section.LENGTH:
+                        continue
+
+                    new_idx = (ny * Section.LENGTH) + nx
+                    nearby_tile = data[new_idx]
+
+                    if nearby_tile == mine_tile:
+                        continue
+
+                    # 숫자 증가
+                    nearby_tile += 1
+                    data[new_idx] = nearby_tile
 
         return Section(p=p, data=data)
 

--- a/board/data/test/section_test.py
+++ b/board/data/test/section_test.py
@@ -114,13 +114,6 @@ class SectionTestCase(unittest.TestCase):
             color=None,
             number=None,
         )
-        closed = Tile.create(
-            is_open=False,
-            is_mine=False,
-            is_flag=False,
-            color=None,
-            number=None,
-        )
 
         sec = Section.create(Point(0, 0))
 
@@ -130,7 +123,48 @@ class SectionTestCase(unittest.TestCase):
 
         self.assertEqual(len(sec.data), total)
         self.assertEqual(sec.data.count(mine.data), mine_count)
-        self.assertEqual(sec.data.count(closed.data), tile_count)
+
+        num_mask = 0b00000111
+        # 숫자 정확한지 확인
+        for y in range(Section.LENGTH):
+            for x in range(Section.LENGTH):
+                idx = (y * Section.LENGTH) + x
+                tile = sec.data[idx]
+                if tile == mine.data:
+                    continue
+
+                got = tile & num_mask
+                expected = check_neighbor_mine_count(sec, Point(x, y))
+
+                self.assertEqual(got, expected)
+
+
+# (x, y)
+DELTA = [
+    (0, 1), (0, -1), (-1, 0), (1, 0),  # 상하좌우
+    (-1, 1), (1, 1), (-1, -1), (1, -1),  # 좌상 우상 좌하 우하
+]
+
+MINE_TILE = 0b01000000
+
+
+def check_neighbor_mine_count(section: Section, pos: Point) -> int:
+    result = 0
+    # 주변 탐색
+    for dx, dy in DELTA:
+        nx, ny = pos.x+dx, pos.y+dy
+        if \
+                nx < 0 or nx >= Section.LENGTH or \
+                ny < 0 or ny >= Section.LENGTH:
+            continue
+
+        new_idx = (ny * Section.LENGTH) + nx
+        nearby_tile = section.data[new_idx]
+
+        if nearby_tile == MINE_TILE:
+            result += 1
+
+    return result
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
지뢰를 찍은 후 타일들을 순회하며 숫자 정보를 추가하는 로직을 작성했습니다.

만약 타일이 지뢰일시, 주변 8칸에 1을 더해줍니다.

일단 지금 코드에선 주변 8칸이 지뢰인 타일이 있을 수 있습니다. -> 이 경우 number bits가 color bits를 침범하게 됩니다.
이 부분에 대한 해결 방안을 고민중인데, 의견 있으시면 말씀해주세요.
한 섹션의 주변 섹션과의 관계(가장자리 맞닿는 부분의 number)도 고려해야 할 것 같습니다.