### PR TITLE
타일 인코딩 hex 적용

### DIFF
--- a/board/data/handler/internal/board.py
+++ b/board/data/handler/internal/board.py
@@ -2,21 +2,21 @@ from board.data import Point, Section, Tile, Tiles
 
 DATA_PATH = "board/data/handler/internal/boarddata"
 
-SECTION_1 = Section.from_str(Point(-1, 0), open(f"{DATA_PATH}/data1.txt", "r").read())
-SECTION_2 = Section.from_str(Point(0, 0), open(f"{DATA_PATH}/data2.txt", "r").read())
-SECTION_3 = Section.from_str(Point(-1, -1), open(f"{DATA_PATH}/data3.txt", "r").read())
-SECTION_4 = Section.from_str(Point(0, -1), open(f"{DATA_PATH}/data4.txt", "r").read())
+# SECTION_1 = Section.from_str(Point(-1, 0), open(f"{DATA_PATH}/data1.txt", "r").read())
+# SECTION_2 = Section.from_str(Point(0, 0), open(f"{DATA_PATH}/data2.txt", "r").read())
+# SECTION_3 = Section.from_str(Point(-1, -1), open(f"{DATA_PATH}/data3.txt", "r").read())
+# SECTION_4 = Section.from_str(Point(0, -1), open(f"{DATA_PATH}/data4.txt", "r").read())
 
 BOARD_DATA = \
     {
-        0: {
-            0: SECTION_2,
-            -1: SECTION_1
-        },
-        -1: {
-            0: SECTION_4,
-            -1: SECTION_3
-        }
+        # 0: {
+        #     0: SECTION_2,
+        #     -1: SECTION_1
+        # },
+        # -1: {
+        #     0: SECTION_4,
+        #     -1: SECTION_3
+        # }
     }
 
 

--- a/board/data/handler/test/board_test.py
+++ b/board/data/handler/test/board_test.py
@@ -2,7 +2,7 @@ import unittest
 from tests.utils import cases
 from board.data import Point, Tile
 from board.data.handler import BoardHandler
-from .fixtures import setup_board_fake
+from .fixtures import setup_board
 
 FETCH_CASE = \
     [
@@ -11,28 +11,36 @@ FETCH_CASE = \
                 "start_p": Point(-2, 1),
                 "end_p": Point(1, -2)
             },
-            "expect": "df12df12er56er56"
+            "expect": "82818170818081018281813983680302"
         },
         {  # 전체
             "data": {
                 "start_p": Point(-4, 3),
                 "end_p": Point(3, -4)
             },
-            "expect": "asdf1234asdf1234asdf1234asdf1234qwer5678qwer5678qwer5678qwer5678"
+            "expect": "0102020100000000014040010101010001028281817001000121818081010100014082818139010181818368030240018080824003400201c080810102010100"
         },
         {  # 한개
             "data": {
                 "start_p": Point(0, 0),
                 "end_p": Point(0, 0)
             },
+<<<<<<< HEAD
             "expect": "1"
         }
+=======
+            "expect": "81"
+        },
+
+        # out of bound
+        # start_x <= end_x & start_y >= end_y
+>>>>>>> 8717a2c (setup_board_fake 제거 및 테스트에 hex 적용)
     ]
 
 
 class BoardHandlerTestCase(unittest.TestCase):
     def setUp(self):
-        setup_board_fake()
+        setup_board()
 
     @cases(FETCH_CASE)
     def test_fetch(self, data, expect):

--- a/board/data/handler/test/board_test.py
+++ b/board/data/handler/test/board_test.py
@@ -25,16 +25,8 @@ FETCH_CASE = \
                 "start_p": Point(0, 0),
                 "end_p": Point(0, 0)
             },
-<<<<<<< HEAD
-            "expect": "1"
-        }
-=======
             "expect": "81"
-        },
-
-        # out of bound
-        # start_x <= end_x & start_y >= end_y
->>>>>>> 8717a2c (setup_board_fake 제거 및 테스트에 hex 적용)
+        }
     ]
 
 

--- a/board/data/handler/test/fixtures.py
+++ b/board/data/handler/test/fixtures.py
@@ -2,40 +2,6 @@ from board.data import Section, Point
 from board.data.handler import BoardHandler
 
 
-def setup_board_fake():
-    """
-     3   a s d f 1 2 3 4
-     2   a s d f 1 2 3 4
-     1   a s d f 1 2 3 4
-     0   a s d f 1 2 3 4
-    -1   q w e r 5 6 7 8
-    -2   q w e r 5 6 7 8
-    -3   q w e r 5 6 7 8
-    -4   q w e r 5 6 7 8
-
-        -4-3-2-1 0 1 2 3
-    """
-
-    Section.LENGTH = 4
-
-    SECTION_1 = Section.from_str(Point(-1, 0), "asdfasdfasdfasdf")
-    SECTION_2 = Section.from_str(Point(0, 0), "1234123412341234")
-    SECTION_3 = Section.from_str(Point(-1, -1), "qwerqwerqwerqwer")
-    SECTION_4 = Section.from_str(Point(0, -1), "5678567856785678")
-
-    BoardHandler.sections = \
-        {
-            0: {
-                0: SECTION_2,
-                -1: SECTION_1
-            },
-            -1: {
-                0: SECTION_4,
-                -1: SECTION_3
-            }
-        }
-
-
 def setup_board():
     """
     /docs/example-map-state.png

--- a/board/data/internal/section.py
+++ b/board/data/internal/section.py
@@ -54,7 +54,7 @@ class Section:
         """
         레거시, 관련 로직 바꿔야 함.
         """
-        return Section(p, bytearray(data, encoding="latin-1"))
+        return Section(p, bytearray.fromhex(data))
 
     @staticmethod
     def create(p: Point):

--- a/board/data/internal/tiles.py
+++ b/board/data/internal/tiles.py
@@ -6,7 +6,7 @@ class Tiles:
     data: bytearray
 
     def to_str(self):
-        return self.data.decode("latin-1")
+        return self.data.hex()
 
     def hide_info(self):
         """

--- a/board/data/test/section_test.py
+++ b/board/data/test/section_test.py
@@ -6,7 +6,9 @@ from board.data import Section, Point, Tile, Tiles
 # 테스트를 위해 Section.LENGTH를 4로 설정
 Section.LENGTH = 4
 
-EXAPMLE_SECTION_DATA = "asdfASDFqwerQWER"
+# hex는 문자 2개 사용하기 때문에 2번 반복
+EXAPMLE_SECTION_DATA = "11223344556677889900aabbccddeeff"
+DATA_LENGTH = (Section.LENGTH ** 2) * 2
 
 EXAMPLE_POINT = Point(x=0, y=Section.LENGTH - 1)
 
@@ -27,7 +29,7 @@ FETCH_TEST_CASES = [
         "range": {
             "start_point": EXAMPLE_POINT
         },
-        "expect": EXAPMLE_SECTION_DATA[0]
+        "expect": EXAPMLE_SECTION_DATA[0: 2]
     },
     {
         "desc": "fetch end",
@@ -37,7 +39,7 @@ FETCH_TEST_CASES = [
                 y=0
             )
         },
-        "expect": EXAPMLE_SECTION_DATA[(Section.LENGTH ** 2) - 1]
+        "expect": EXAPMLE_SECTION_DATA[DATA_LENGTH - 2:]
     }
 ]
 
@@ -96,7 +98,7 @@ class SectionTestCase(unittest.TestCase):
         cols = 3
 
         # 업데이트용 row * col 크기의 2D bytearray 생성
-        data = bytearray().join([bytearray(f"{i}"*cols, "latin-1") for i in range(rows)])
+        data = bytearray().join([bytearray.fromhex(f"{i}{i}")*cols for i in range(rows)])
         value = Tiles(data)
         start = EXAMPLE_POINT
         end = Point(2, 1)

--- a/board/data/test/tiles_test.py
+++ b/board/data/test/tiles_test.py
@@ -5,12 +5,12 @@ import unittest
 
 class TilesTestCase(unittest.TestCase):
     def test_to_str(self):
-        data = bytearray().join([bytearray("abc", "latin-1") for _ in range(3)])
+        data = bytearray().join([bytearray.fromhex("abcd") for _ in range(3)])
         tiles = Tiles(data=data)
 
         s = tiles.to_str()
 
-        self.assertEqual(s, "abcabcabc")
+        self.assertEqual(s, "abcdabcdabcd")
 
     def test_hide_info(self):
         open_tile = Tile.create(

--- a/server_test.py
+++ b/server_test.py
@@ -4,7 +4,7 @@ from fastapi.websockets import WebSocketDisconnect
 from server import app
 from message import Message
 from message.payload import FetchTilesPayload, TilesPayload, TilesEvent, NewConnEvent
-from board.data.handler.test.fixtures import setup_board_fake
+from board.data.handler.test.fixtures import setup_board
 from board.event.handler import BoardEventHandler
 from board.data import Point, Tile, Tiles
 from event import EventBroker
@@ -16,7 +16,7 @@ from unittest.mock import AsyncMock, patch
 
 class ServerTestCase(unittest.TestCase):
     def setUp(self):
-        setup_board_fake()
+        setup_board()
         self.client = TestClient(app)
 
         self.client.headers["X-View-Tiles-Width"] = "1"

--- a/server_test.py
+++ b/server_test.py
@@ -60,26 +60,19 @@ class ServerTestCase(unittest.TestCase):
                 )
             )
 
-            empty_open = Tile.from_int(0b10000000)
-            one_open = Tile.from_int(0b10000001)
-            expected = Tiles(data=bytearray([
-                empty_open.data, one_open.data, one_open.data, one_open.data
-            ]))
-
             expect = Message(
                 event=TilesEvent.TILES,
                 payload=TilesPayload(
                     start_p=Point(-2, 1),
                     end_p=Point(1, -2),
-                    tiles=expected.to_str()
+                    tiles="82818130818081008281813883280000"
                 )
             )
 
             websocket.send_text(msg.to_str())
 
-            # TODO: 이거 고치기
-            # response = websocket.receive_text()
-            # self.assertEqual(response, expect.to_str())
+            response = websocket.receive_text()
+            self.assertEqual(response, expect.to_str())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
현재 tile을 그대로 인코딩 하게 되면 ascii, utf-8에서는 오류가 발생합니다.
또한, latin1에서는 제어문자와 같은 문자들이 \x00 같이 4바이트로 표현됩니다.

\x00의 상황은 현재 닫힌 타일에 해당합니다. 또한, 일반적인 열린 타일들 또한 latin1에서 4바이트로 표현됩니다. 
지뢰가 없는 열린 타일은 0b10000XXX = 0x8X 인데, latin1의 코드표를 보면 딱 그 위치가 매핑이 없는 위치입니다.

<img width="534" alt="image" src="https://github.com/user-attachments/assets/bc87f8e0-d71a-4293-9cdc-b2a668cf9458">


이를 일시적으로 해결하기 위해 하나의 타일을 2바이트짜리 hex로 인코딩하여 사용하기로 결정하였습니다.


이를 적용시키면 텍스트 인코딩은 어떤 것으로 할지는 자유롭게 정해도 될 것 같습니다.