### PR TITLE
Fast Forward branch 비교 삭제

### DIFF
--- a/.github/workflows/fast-forward-merge.yml
+++ b/.github/workflows/fast-forward-merge.yml
@@ -9,7 +9,6 @@ jobs:
     if: |
       github.event.issue.pull_request && 
       contains(github.event.comment.body, '/fast-forward') && 
-      (github.head_ref == 'develop' && github.base_ref == 'main') &&
       (github.triggering_actor == 'onee-only' || github.triggering_actor == 'byundojin')
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
[자료](https://github.com/orgs/community/discussions/49628)에 따르면 issue comment가 생겼을 땐 base_ref와 head_ref가 전달되지 않는다고 합니다.
이 때문에 ref 비교 문이 언제나 false를 뱉어 fast-forward가 실행되지 않았습니다.