### PR TITLE
섹션 생성 시 주변 섹션에 적용 로직 추가

### DIFF
--- a/board/data/__init__.py
+++ b/board/data/__init__.py
@@ -1,5 +1,5 @@
 from .internal.point import Point
-from .internal.section import Section, for_each_neighbor
+from .internal.section import Section
 from .internal.tile import Tile
 from .internal.tiles import Tiles
 from .internal.tile_exception import InvalidTileException

--- a/board/data/handler/internal/board.py
+++ b/board/data/handler/internal/board.py
@@ -78,7 +78,35 @@ class BoardHandler:
 
         if x not in BoardHandler.sections[y]:
             new_section = Section.create(Point(x, y))
-            # TODO: 주변 섹션과의 접경타일들 숫자 업데이트
+
+            # (x, y)
+            delta = [
+                (0, 1), (0, -1), (-1, 0), (1, 0),  # 상하좌우
+                (-1, 1), (1, 1), (-1, -1), (1, -1),  # 좌상 우상 좌하 우하
+            ]
+
+            # 주변 섹션과 새로운 섹션의 인접 타일을 서로 적용시킨다.
+            for dx, dy in delta:
+                nx, ny = x+dx, y+dy
+                neighbor = BoardHandler._get_section_or_none(nx, ny)
+                # 주변 섹션이 없을 수 있음.
+                if neighbor is None:
+                    continue
+
+                if dx != 0 and dy != 0:
+                    neighbor.apply_neighbor_diagonal(new_section)
+                elif dx != 0:
+                    neighbor.apply_neighbor_horizontal(new_section)
+                elif dy != 0:
+                    neighbor.apply_neighbor_vertical(new_section)
+
+                BoardHandler.sections[ny][nx] = neighbor
+
             BoardHandler.sections[y][x] = new_section
 
         return BoardHandler.sections[y][x]
+
+    @staticmethod
+    def _get_section_or_none(x: int, y: int) -> Section | None:
+        if y in BoardHandler.sections and x in BoardHandler.sections[y]:
+            return BoardHandler.sections[y][x]

--- a/board/data/handler/test/board_test.py
+++ b/board/data/handler/test/board_test.py
@@ -44,16 +44,6 @@ class BoardHandlerTestCase(unittest.TestCase):
 
         self.assertEqual(data,  expect)
 
-    def test_fetch_out_of_bounds(self):
-        # 오른쪽 섹션 추가
-        start = Point(4, 3)
-        end = Point(6, 1)
-
-        BoardHandler.fetch(start, end)
-
-        sx, sy = 1, 0
-        self.assertIsNotNone(BoardHandler.sections[sy][sx])
-
     def test_update_tile(self):
         p = Point(-1, -1)
 

--- a/board/data/internal/section.py
+++ b/board/data/internal/section.py
@@ -4,6 +4,9 @@ from .tiles import Tiles
 from random import randint
 from typing import Callable
 
+MINE_TILE = 0b01000000
+NUM_MASK = 0b00000111
+
 
 class Section:
     LENGTH = 100
@@ -51,6 +54,116 @@ class Section:
     def abs_y(self):
         return self.p.y * Section.LENGTH
 
+    def apply_neighbor_diagonal(self, neighbor):
+        """
+        대각선 방향에서 인접한 섹션을 서로 적용.
+        각 섹션의 꼭짓점 부분만 체크하면 된다.
+        """
+        if self.p.y > neighbor.p.y:
+            self_y = Section.LENGTH - 1
+            neighbor_y = 0
+        else:
+            self_y = 0
+            neighbor_y = Section.LENGTH - 1
+
+        if self.p.x > neighbor.p.x:
+            self_x = 0
+            neighbor_x = Section.LENGTH - 1
+        else:
+            self_x = Section.LENGTH - 1
+            neighbor_x = 0
+
+        self_idx = (self_y * Section.LENGTH) + self_x
+        neighbor_idx = (neighbor_y * Section.LENGTH) + neighbor_x
+
+        if self.data[self_idx] == MINE_TILE:
+            affect_origin_mines_to_new(
+                new_tiles=neighbor.data,
+                x_range=(neighbor_x, neighbor_x),
+                y_range=(neighbor_y, neighbor_y)
+            )
+
+        if neighbor.data[neighbor_idx] == MINE_TILE:
+            affect_new_mines_to_origin(
+                origin_tiles=self.data,
+                new_tiles=neighbor.data,
+                mine_p=Point(neighbor_x, neighbor_y),
+                x_range=(self_x, self_x),
+                y_range=(self_y, self_y)
+            )
+
+    def apply_neighbor_vertical(self, neighbor):
+        """
+        수직 방향에서 인접한 섹션을 서로 적용.
+        상하 모서리를 수평 방향으로 적용시킨다.
+        """
+        if self.p.y > neighbor.p.y:
+            self_y = Section.LENGTH - 1
+            neighbor_y = 0
+        else:
+            self_y = 0
+            neighbor_y = Section.LENGTH - 1
+
+        for x in range(Section.LENGTH):
+            self_idx = (self_y * Section.LENGTH) + x
+            neighbor_idx = (neighbor_y * Section.LENGTH) + x
+
+            # 현재 위치가 mine일 시 상대 섹션에 적용시킬 x 범위
+            leftmost = max(0, x - 1)
+            rightmost = min(x + 1, Section.LENGTH - 1)
+
+            if self.data[self_idx] == MINE_TILE:
+                affect_origin_mines_to_new(
+                    new_tiles=neighbor.data,
+                    x_range=(leftmost, rightmost),
+                    y_range=(neighbor_y, neighbor_y)
+                )
+
+            if neighbor.data[neighbor_idx] == MINE_TILE:
+                affect_new_mines_to_origin(
+                    origin_tiles=self.data,
+                    new_tiles=neighbor.data,
+                    mine_p=Point(x, neighbor_y),
+                    x_range=(leftmost, rightmost),
+                    y_range=(self_y, self_y)
+                )
+
+    def apply_neighbor_horizontal(self, neighbor):
+        """
+        수평 방향에서 인접한 섹션을 서로 적용.
+        좌우 모서리를 수직 방향으로 적용시킨다.
+        """
+        if self.p.x > neighbor.p.x:
+            self_x = 0
+            neighbor_x = Section.LENGTH - 1
+        else:
+            self_x = Section.LENGTH - 1
+            neighbor_x = 0
+
+        for y in range(Section.LENGTH):
+            self_idx = (y * Section.LENGTH) + self_x
+            neighbor_idx = (y * Section.LENGTH) + neighbor_x
+
+            # 현재 위치가 mine일 시 상대 섹션에 적용시킬 y 범위
+            top = min(y + 1, Section.LENGTH - 1)
+            bottom = max(0, y - 1)
+
+            if self.data[self_idx] == MINE_TILE:
+                affect_origin_mines_to_new(
+                    new_tiles=neighbor.data,
+                    x_range=(neighbor_x, neighbor_x),
+                    y_range=(bottom, top)
+                )
+
+            if neighbor.data[neighbor_idx] == MINE_TILE:
+                affect_new_mines_to_origin(
+                    origin_tiles=self.data,
+                    new_tiles=neighbor.data,
+                    mine_p=Point(neighbor_x, y),
+                    x_range=(self_x, self_x),
+                    y_range=(bottom, top)
+                )
+
     @staticmethod
     def from_str(p: Point, data: str):
         """
@@ -62,9 +175,6 @@ class Section:
     def create(p: Point):
         total = Section.LENGTH**2
         mine_cnt = int((total * Section.MINE_RATIO)//1)
-
-        mine = 0b01000000
-        num_mask = 0b00000111
 
         # zero-value로 초기화됨,
         data = bytearray(total)
@@ -81,40 +191,155 @@ class Section:
                 cur_tile = data[rand_idx]
 
                 # 이미 지뢰가 존재
-                if cur_tile == mine:
+                if cur_tile == MINE_TILE:
                     continue
 
                 # 주변 타일 검사
-                invalid = False
-
-                def check_neighbor_restrictions(t: int) -> tuple[Tile | None, bool]:
-                    nonlocal invalid
-                    # 주변 타일이 7을 넘지 않아야 함
-                    if t & num_mask == 7:
-                        invalid = True
-
-                    return None, invalid
-
-                for_each_neighbor(tiles=data, p=rand_p, func=check_neighbor_restrictions)
-                if invalid:
+                valid = check_neighbor_restrictions(tiles=data, p=rand_p)
+                if not valid:
                     continue
 
-                data[rand_idx] = mine
+                data[rand_idx] = MINE_TILE
 
                 # 주변 타일 숫자 증가
-                def increase_number(t: int) -> tuple[Tile | None, bool]:
-                    if t == mine:
-                        return None, False
-
-                    t += 1
-
-                    return t, False
-
-                for_each_neighbor(tiles=data, p=rand_p, func=increase_number)
-
+                increase_number_around(tiles=data, p=rand_p)
                 break
 
         return Section(p=p, data=data)
+
+
+def affect_origin_mines_to_new(new_tiles: bytearray, x_range: tuple[int, int], y_range: tuple[int, int]):
+    """
+    기존 존재하는 섹션(origin)의 지뢰들을 새로 들어온 섹션(new)의 타일에 적용
+    -> origin에 지뢰가 존재 -> new에 위치한 인접 타일들 num += 1
+    만약 new의 인접 타일이 7이면, 그 타일 주변 지뢰를 하나 제거한다.
+
+    x_range, y_range 범위에 위치한 new 타일을 1씩 더해준다.
+    """
+    for y in range(y_range[0], y_range[1] + 1):
+        for x in range(x_range[0], x_range[1] + 1):
+            idx = (y * Section.LENGTH) + x
+
+            tile = new_tiles[idx]
+            if tile == MINE_TILE:
+                continue
+
+            num = tile & NUM_MASK
+            if num == 7:
+                # new의 num이 7이라면 주변 지뢰 1개 제거하여 origin의 지뢰를 적용시킬 수 있도록 한다.
+                remove_one_nearby_mine(new_tiles, Point(x, y))
+            else:
+                tile += 1
+            new_tiles[idx] = tile
+
+
+def affect_new_mines_to_origin(
+    origin_tiles: bytearray, new_tiles: bytearray, mine_p: Point,
+    x_range: tuple[int, int], y_range: tuple[int, int]
+):
+    """
+    새로 들어온 섹션(new)의 지뢰들을 기존 존재하는 섹션(origin)의 타일에 적용
+    -> new에 지뢰가 존재 -> origin에 위치한 인접 타일들 num += 1
+    만약 origin의 인접 타일이 7이면, new의 지뢰를 삭제한다.
+
+    x_range, y_range 범위에 위치한 origin 타일을 1씩 더해준다.
+    """
+    for y in range(y_range[0], y_range[1] + 1):
+        for x in range(x_range[0], x_range[1] + 1):
+            idx = (y * Section.LENGTH) + x
+
+            tile = origin_tiles[idx]
+            if tile == MINE_TILE:
+                continue
+
+            num = tile & NUM_MASK
+            if num == 7:
+                # origin의 num이 7이다.
+                # 이 경우에는 new의 지뢰를 제거하고 숫자로 덮어씌워준다.
+                cnt = decrease_number_around_and_count_mines(
+                    tiles=new_tiles,
+                    p=mine_p
+                )
+
+                new_tiles_idx = (mine_p.y * Section.LENGTH) + mine_p.x
+                new_tiles[new_tiles_idx] = cnt
+                continue
+
+            origin_tiles[idx] = num + 1
+
+
+def decrease_number_around_and_count_mines(tiles: bytearray, p: Point) -> int:
+    """
+    주변 8칸 타일들의 num을 1씩 감소시킨다.
+    만약 타일이 지뢰라면, cnt++ 해준다.
+    """
+    cnt = 0
+
+    def do(t: int, p: Point) -> tuple[int | None, bool]:
+        nonlocal cnt
+        if t == MINE_TILE:
+            cnt += 1
+            return None, False
+
+        t -= 1
+        return t, False
+
+    for_each_neighbor(tiles, p, do)
+
+    return cnt
+
+
+def remove_one_nearby_mine(tiles: bytearray, p: Point):
+    """
+    주변 타일 중 지뢰 타일 하나를 제거한다.
+    지뢰 타일은 주변 지뢰 개수 숫자로 덮어씌워지며,
+    그 주변 타일의 num은 1씩 감소한다.
+    """
+    def do(t: int, p: Point) -> tuple[int | None, bool]:
+        if t != MINE_TILE:
+            return None, False
+
+        cnt = decrease_number_around_and_count_mines(tiles=tiles, p=p)
+        return cnt, True
+
+    for_each_neighbor(tiles, p, do)
+
+
+def increase_number_around(tiles: bytearray, p: Point):
+    """
+    주변 타일의 num을 1씩 증가시킨다.
+    """
+    def do(t: int, p: Point) -> tuple[int | None, bool]:
+        if t == MINE_TILE:
+            return None, False
+
+        t += 1
+
+        return t, False
+
+    for_each_neighbor(tiles, p, do)
+
+
+def check_neighbor_restrictions(tiles: bytearray, p: Point) -> bool:
+    """
+    mine이 생길 타일 주변 타일의 제약사항을 검사하여 valid한지 반환한다.
+    valid하면 True.
+
+    1. num이 7인가? -> mine을 더 추가하면 8이 된다.
+    """
+    valid = True
+
+    def do(t: int, p: Point) -> tuple[int | None, bool]:
+        nonlocal valid
+        # 주변 타일이 7을 넘지 않아야 함
+        if t & NUM_MASK == 7:
+            valid = False
+
+        return None, not valid
+
+    for_each_neighbor(tiles, p, do)
+
+    return valid
 
 
 # (x, y)
@@ -124,7 +349,7 @@ _delta = [
 ]
 
 
-def for_each_neighbor(tiles: bytearray, p: Point, func: Callable[[int], tuple[int | None, bool]]):
+def for_each_neighbor(tiles: bytearray, p: Point, func: Callable[[int, Point], tuple[int | None, bool]]):
     """
     p(section 내부 좌표)의 주변 8방향의 인접 타일을 돌며 func를 실행.
     만약 인접 타일이 section의 범위를 벗어난다면 무시함.
@@ -145,17 +370,9 @@ def for_each_neighbor(tiles: bytearray, p: Point, func: Callable[[int], tuple[in
         new_idx = (np.y * Section.LENGTH) + np.x
         nearby_tile = tiles[new_idx]
 
-        tile, stop = func(nearby_tile)
+        tile, stop = func(nearby_tile, np)
         if tile is not None:
             tiles[new_idx] = tile
 
         if stop:
             break
-
-
-if __name__ == "__main__":
-    sec = Section.create(Point(0, 0))
-    for i in range(100):
-        print("".join(map(lambda x: "m" if x == 0b01000000 else "c", sec.data[i*100:(i+1)*100])))
-    print(sec.data.count(0b01000000))
-    print(sec.data.count(0b00000000))

--- a/board/data/test/__init__.py
+++ b/board/data/test/__init__.py
@@ -1,6 +1,6 @@
 import unittest
 
-from .section_test import SectionTestCase
+from .section_test import SectionTestCase, SectionApplyNeighborTestCase
 from .tile_test import TileTestCase
 from .tiles_test import TilesTestCase
 


### PR DESCRIPTION
인접 타일을 적용시켰을 때, number가 8이 되는 타일이 생기는 상황이 생기면, 새로 들어온 섹션의 지뢰를 하나 제거하는 방식으로 만들었습니다.

현재 대각선, 수직, 수평이 메서드가 나눠져 있는데, 하나로 합치는 건 어떨까 생각중입니다.
계속 작성하다가 코드가 더러워져서 리팩을 계속 했는데, 만약 쉽게 이해가 되지 않는다면 개선 사항으로 리뷰 남겨주시면 감사하겠습니다.